### PR TITLE
Uniformized the msbuild property used to define the Version.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
         run: dotnet build -c Release -p:Version=$Version ./HomographySharp/HomographySharp.csproj
 
       - name: "dotnet pack"
-        run: dotnet pack -c Release --no-build --include-symbols --output $GITHUB_WORKSPACE/artifacts -p:PackageVersion=$Version ./HomographySharp/HomographySharp.csproj
+        run: dotnet pack -c Release --no-build --include-symbols --output $GITHUB_WORKSPACE/artifacts -p:Version=$Version ./HomographySharp/HomographySharp.csproj
 
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
MSBuild allows us to set various properties related to version, such as `AssemblyVersion`, `FileVersion`, and `PackageVersion`. However, since these all reference `Version`, I thought it would be better to unify to `Version`.