### PR TITLE
drop netstandard2.1

### DIFF
--- a/HomographySharp/HomographySharp.csproj
+++ b/HomographySharp/HomographySharp.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net6.0;</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netcoreapp3.1;net6.0;</TargetFrameworks>
         <LangVersion>10</LangVersion>
         <Nullable>enable</Nullable>
 
@@ -23,10 +23,6 @@
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
         <PackageReference Include="System.Memory" Version="4.5.*" />
         <PackageReference Include="System.Numerics.Vectors" Version="4.5.*" />
-        <PackageReference Include="System.Text.Json" Version="6.0.*" />
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
         <PackageReference Include="System.Text.Json" Version="6.0.*" />
     </ItemGroup>
 


### PR DESCRIPTION
Drop netstandard2.1 because System.Text.Json does not support netstandard2.1.
This is due to a dependency included in System.Text.Json, which does not make sense to support netstandard 2.1.