### PR TITLE
drop netcoreapp3.1

### DIFF
--- a/HomographySharp/HomographySharp.csproj
+++ b/HomographySharp/HomographySharp.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netcoreapp3.1;net6.0;</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net6.0;</TargetFrameworks>
         <LangVersion>10</LangVersion>
         <Nullable>enable</Nullable>
 


### PR DESCRIPTION
.NET Core 3.1 is no longer supported.
https://dotnet.microsoft.com/en-us/download/dotnet